### PR TITLE
Update Docs and Remove Unnecessary Queue Normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ python kyuubi_submit.py --config-file job-config.yaml
 | `--resource` | Yes | Path to JAR or Python file | `s3a://bucket/app.jar` |
 | `--classname` | No* | Main class name (*required for JAR files) | `com.example.MainClass` |
 | `--name` | Yes | Job name | `"Production ETL Job"` |
+| `--queue` | No | Queue name | `"YuniKorn queue name to submit the job into"` |
 | `--args` | No | Space-separated job arguments | `"input.csv output.parquet"` |
 | `--conf` | No | Comma-separated Spark configurations | `"spark.executor.memory=4g,spark.executor.instances=10"` |
 | `--pyfiles` | No | Comma-separated Python dependencies | `"utils.py,libs.zip"` |
@@ -212,6 +213,7 @@ python kyuubi_submit.py \
   --resource s3a://bucket/main-app.jar \
   --classname com.company.analytics.MainJob \
   --name "Analytics-Pipeline" \
+  --queue "analytics" \
   --args "--date 2024-01-01 --mode production" \
   --jars "s3a://bucket/lib/postgres-driver.jar,s3a://bucket/lib/custom-udfs.jar" \
   --conf "spark.executor.memory=16g,spark.executor.instances=50,spark.sql.adaptive.enabled=true" \
@@ -226,6 +228,7 @@ server: https://kyuubi.example.com
 username: data-scientist@company.com
 resource: s3a://ml-bucket/train_model.py
 name: ML-Model-Training
+queue: analytics
 
 args:
   - --model-type

--- a/kyuubi-submit.py
+++ b/kyuubi-submit.py
@@ -325,11 +325,6 @@ def get_password(config, username):
     
     return password
 
-def normalize_queue(queue_name):
-    if not queue_name.startswith("root."):
-        return f"root.default.{queue_name}"
-    return queue_name
-
 def inject_yunikorn_spark_configs(config):
     """Sets Spark configs for YuniKorn queue labels and user.info annotations."""
     if 'sparkConf' not in config:
@@ -337,8 +332,7 @@ def inject_yunikorn_spark_configs(config):
 
     queue = config.get("queue")
     if queue:
-        queue = normalize_queue(queue)
-        logging.getLogger('kyuubi-submit').debug(f"Queue name after normalizing: {queue}")
+        logging.getLogger('kyuubi-submit').debug(f"Queue name: {queue}")
         # Set YuniKorn queue labels for driver and executor
         config['sparkConf']["spark.kubernetes.driver.label.queue"] = queue
         config['sparkConf']["spark.kubernetes.executor.label.queue"] = queue


### PR DESCRIPTION
This PR includes the following updates:

- Updated README to document the YuniKorn queue option
Added documentation to the README to inform users about the ability to specify a YuniKorn queue during job submission.

- Removed unnecessary queue name normalization
Simplified the code by removing logic that normalized the queue name, as it is not required.