### PR TITLE
Require explicit appState to confirm Spark job success

### DIFF
--- a/java/src/main/java/com/nx1/kyuubi/KyuubiClient.java
+++ b/java/src/main/java/com/nx1/kyuubi/KyuubiClient.java
@@ -48,6 +48,9 @@ public class KyuubiClient implements Closeable {
     /** Python / zip / egg file extensions that imply a PYSPARK batch type. */
     private static final Set<String> PYTHON_EXTENSIONS = Set.of(".py", ".zip", ".egg");
 
+    /** Application-level states that confirm the Spark job genuinely succeeded. */
+    private static final Set<String> SUCCESS_APP_STATES = Set.of("FINISHED", "SUCCEEDED", "SUCCESS");
+
     private final KyuubiClientConfig config;
     private final KyuubiRestClient   rest;
     private final PathClassifier     classifier;
@@ -139,6 +142,14 @@ public class KyuubiClient implements Closeable {
     /**
      * Block until the batch reaches a terminal state.
      *
+     * <p>The returned state reflects the <em>application</em> outcome, not merely
+     * the batch lifecycle: a batch that reaches {@code FINISHED} is only returned
+     * as {@link BatchState#FINISHED} when the Spark application state explicitly
+     * confirms success. A finished batch whose {@code appState} reports a failure
+     * is returned as {@link BatchState#ERROR}, and one with no {@code appState}
+     * (success unconfirmable) is returned as {@link BatchState#UNKNOWN}. This means
+     * {@code monitor(id) == BatchState.FINISHED} is a safe success check.
+     *
      * @param batchId     the batch to monitor
      * @param logConsumer optional callback invoked with each log line once the
      *                    job finishes; pass {@code null} to skip log retrieval
@@ -200,6 +211,19 @@ public class KyuubiClient implements Closeable {
 
                 if (logConsumer != null) {
                     fetchAndStreamLogs(batchId, logConsumer);
+                }
+
+                // Batch FINISHED != Spark success: downgrade unless appState confirms it,
+                // so a caller checking for FINISHED can't mistake a failed job for success.
+                if (state == BatchState.FINISHED && !isAppSuccess(appState)) {
+                    if (appState == null || appState.isBlank()) {
+                        log.error("Batch reached FINISHED but Kyuubi reported no application "
+                                + "state (appState) — cannot confirm the Spark job succeeded");
+                        return BatchState.UNKNOWN;
+                    }
+                    log.error("Batch reached FINISHED but Spark application state is '{}' "
+                            + "— treating as failure", appState);
+                    return BatchState.ERROR;
                 }
 
                 return state;
@@ -277,6 +301,11 @@ public class KyuubiClient implements Closeable {
     }
 
     // ── Internal helpers ──────────────────────────────────────────────────────
+
+    /** True only when appState explicitly confirms success; null/blank counts as not-success. */
+    private static boolean isAppSuccess(String appState) {
+        return appState != null && SUCCESS_APP_STATES.contains(appState.trim().toUpperCase());
+    }
 
     private boolean isPythonResource(String resource) {
         String lower = resource.toLowerCase();

--- a/java/src/test/java/com/nx1/kyuubi/KyuubiClientTest.java
+++ b/java/src/test/java/com/nx1/kyuubi/KyuubiClientTest.java
@@ -147,6 +147,26 @@ class KyuubiClientTest {
         assertEquals(List.of("line1", "line2"), captured);
     }
 
+    @Test
+    void monitorReturnsErrorWhenFinishedButAppFailed() throws Exception {
+        wm.stubFor(get(urlEqualTo("/api/v1/batches/batch-006"))
+                .willReturn(okJson("{\"id\":\"batch-006\",\"state\":\"FINISHED\",\"appState\":\"FAILED\"}")));
+
+        try (KyuubiClient client = newClient()) {
+            assertEquals(BatchState.ERROR, client.monitor("batch-006"));
+        }
+    }
+
+    @Test
+    void monitorReturnsUnknownWhenFinishedButNoAppState() throws Exception {
+        wm.stubFor(get(urlEqualTo("/api/v1/batches/batch-007"))
+                .willReturn(okJson("{\"id\":\"batch-007\",\"state\":\"FINISHED\"}")));
+
+        try (KyuubiClient client = newClient()) {
+            assertEquals(BatchState.UNKNOWN, client.monitor("batch-007"));
+        }
+    }
+
     // ── cancel ─────────────────────────────────────────────────────────────────
 
     @Test

--- a/python/kyuubi-submit.py
+++ b/python/kyuubi-submit.py
@@ -460,8 +460,6 @@ class KyuubiBatchSubmitter:
                         elapsed_min = elapsed // 60
                         elapsed_sec = elapsed % 60
                         self.logger.info(f"Job completed in {elapsed_min}m {elapsed_sec}s")
-                        if app_state:
-                            self.logger.info(f"Final application state: {app_state}")
                         app_diagnostic = status.get('appDiagnostic', '')
                         if app_diagnostic:
                             self.logger.info(f"Application diagnostics: {app_diagnostic}")
@@ -469,7 +467,17 @@ class KyuubiBatchSubmitter:
                             self.print_all_logs(batch_id)
                         else:
                             self.logger.info("Logs available but not displayed (use --show-logs to see them)")
-                        return app_state if app_state else state
+
+                        # Batch FINISHED != Spark success: require an explicit appState
+                        # rather than falling back to the batch state.
+                        if not app_state:
+                            self.logger.error(
+                                "Batch reached FINISHED but Kyuubi reported no application "
+                                "state (appState) - cannot confirm the Spark job succeeded"
+                            )
+                            return 'UNKNOWN'
+                        self.logger.info(f"Final application state: {app_state}")
+                        return app_state
                     
                     elif state in ['ERROR', 'CANCELLED']:
                         sys.stdout.write('\r' + ' '*80 + '\r')


### PR DESCRIPTION
A FINISHED batch state does not prove the Spark application succeeded. Both clients previously treated a FINISHED batch as success even when appState was missing or reported a failure.

- Python: monitor_job no longer falls back to the batch state when appState is empty; it returns UNKNOWN so the caller exits non-zero.
- Java: monitor() now returns ERROR when a FINISHED batch has a failed appState and UNKNOWN when appState is missing, so == FINISHED is a safe success check. Adds SUCCESS_APP_STATES and tests.