### PR TITLE
WF-292: Print kyuubi pod name on successful jobs

### DIFF
--- a/python/kyuubi-submit.py
+++ b/python/kyuubi-submit.py
@@ -461,6 +461,7 @@ class KyuubiBatchSubmitter:
                         elapsed_sec = elapsed % 60
                         self.logger.info(f"Job completed in {elapsed_min}m {elapsed_sec}s")
                         app_diagnostic = status.get('appDiagnostic', '')
+                        self.logger.info(f"Spark driver pod: kyuubi-spark-{batch_id}-driver")
                         if app_diagnostic:
                             self.logger.info(f"Application diagnostics: {app_diagnostic}")
                         if show_logs:
@@ -483,6 +484,7 @@ class KyuubiBatchSubmitter:
                         sys.stdout.write('\r' + ' '*80 + '\r')
                         self.logger.error(f"Batch terminated with state: {state}")
                         app_diagnostic = status.get('appDiagnostic', '')
+                        self.logger.error(f"Spark driver pod: kyuubi-spark-{batch_id}-driver")
                         if app_diagnostic:
                             self.logger.error(f"Application diagnostics: {app_diagnostic}")
                         if show_logs:


### PR DESCRIPTION
## Summary
Fixes pod name not being printed on successful Kyuubi batch job completion. Previously, the Spark driver pod name was only surfaced in logs when a job failed (via `appDiagnostic`, which Kyuubi only populates on failure). On successful completion, no pod name was ever logged.

## Root Cause
`appDiagnostic` is populated by Kyuubi only on failure. The success path had no mechanism to surface the driver pod name. 