### PR TITLE
Revert "Guard against remote resource + local file uploads

### DIFF
--- a/java/USAGE.md
+++ b/java/USAGE.md
@@ -233,24 +233,13 @@ SubmitOptions opts = SubmitOptions.builder()
 
 ```java
 SubmitOptions opts = SubmitOptions.builder()
-    .resource("/tmp/build/job.py")                   // LOCAL main script → uploaded
+    .resource("s3a://nx1-jobs/etl/job.py")           // remote main script
     .pyFile("/tmp/build/hot_fix.zip")                // LOCAL patch → uploaded
     .pyFile("s3a://nx1-libs/python/base_utils.zip")  // remote dep → conf only
     .jar("hdfs://nn/apps/jars/connector-3.1.jar")    // remote jar → conf only
     .name("patched-etl")
     .build();
 ```
-
-> **Limitation — remote resource + local extra files.** You cannot upload local
-> `pyFile`/`jar`/`file` entries while the main `resource` is a **remote** URI
-> (above, the resource is local for exactly this reason). That combination produces
-> a multipart request with no main resource file, which trips a Kyuubi
-> **server-side** bug: its upload endpoint calls `ContentDisposition.getFileName()`
-> on the absent resource part and throws a `NullPointerException`, surfacing as an
-> opaque HTTP 500. The client rejects this combination up front with a clear error.
-> To work around it, either pass a **local** path for `resource` (so it is uploaded
-> alongside the files) or stage the extra files to S3/HDFS and pass them as remote
-> URIs. This is a Kyuubi server defect tracked separately (NX-2454).
 
 Path classification rules (mirrors the original Python logic):
 

--- a/java/src/main/java/com/nx1/kyuubi/KyuubiClient.java
+++ b/java/src/main/java/com/nx1/kyuubi/KyuubiClient.java
@@ -87,30 +87,6 @@ public class KyuubiClient implements Closeable {
         PathClassifier.Classification jarClassified = classifier.classify(options.getJars());
         PathClassifier.Classification fileClassified= classifier.classify(options.getFiles());
 
-        // Guard against an unsupported combination: a remote resource together with
-        // local extra files. That forces a multipart upload with NO resourceFile part,
-        // which trips a Kyuubi server bug — the multipart endpoint calls
-        // ContentDisposition.getFileName() on the (absent) resourceFile part and throws
-        // a NullPointerException, surfacing as an opaque HTTP 500. Fail fast instead.
-        if (!resourceIsLocal
-                && (!pyClassified.localFiles.isEmpty()
-                || !jarClassified.localFiles.isEmpty()
-                || !fileClassified.localFiles.isEmpty())) {
-            List<String> offending = new java.util.ArrayList<>();
-            pyClassified.localFiles.forEach(lf -> offending.add(lf.original()));
-            jarClassified.localFiles.forEach(lf -> offending.add(lf.original()));
-            fileClassified.localFiles.forEach(lf -> offending.add(lf.original()));
-            throw new IllegalArgumentException(
-                    "Cannot upload local files when the resource is a remote URI (" + resource + "). "
-                    + "Kyuubi only accepts uploaded extra files when the main resource is also "
-                    + "uploaded; submitting local files without a local resource triggers a "
-                    + "server-side error (HTTP 500, ContentDisposition.getFileName()). "
-                    + "Local files that cannot be uploaded here: " + String.join(", ", offending) + ". "
-                    + "Resolve by either (1) passing a local path for the resource so it is uploaded "
-                    + "with the files, or (2) staging these files to S3/HDFS and passing them as remote "
-                    + "URIs (s3a://, hdfs://, ...), which submits the job without any file upload.");
-        }
-
         // Build the Spark conf map
         Map<String, String> conf = buildConf(options, pyClassified, jarClassified, fileClassified);
 

--- a/python/README.md
+++ b/python/README.md
@@ -149,17 +149,6 @@ In this example:
 - `config.json` → uploaded to Kyuubi
 - `s3a://bucket/data.csv` → passed to Spark as-is
 
-> **Limitation — remote resource + local extra files.** You cannot upload local
-> `--files`/`--jars`/`--pyfiles` while `--resource` is a **remote** URI. That
-> combination produces a multipart request with no main resource file, which
-> trips a Kyuubi **server-side** bug: its upload endpoint calls
-> `ContentDisposition.getFileName()` on the absent resource part and throws a
-> `NullPointerException`, surfacing as an opaque `Failed to submit batch: 500`.
-> The client rejects this combination up front with a clear error. To work around
-> it, either pass a **local** path for `--resource` (so it is uploaded alongside
-> the files) or stage the extra files to S3/HDFS and pass them as remote URIs.
-> This is a Kyuubi server defect tracked separately (NX-2454).
-
 ## Configuration
 
 ### Command Line Options

--- a/python/kyuubi-submit.py
+++ b/python/kyuubi-submit.py
@@ -198,28 +198,7 @@ class KyuubiBatchSubmitter:
         
         # Check if we need multipart upload
         has_local_files = resource_is_local or local_py_files or local_jars or local_files
-
-        # Guard against an unsupported combination: a remote --resource together with
-        # local extra files. That forces a multipart upload with NO resourceFile part,
-        # which trips a Kyuubi server bug — the multipart endpoint calls
-        # ContentDisposition.getFileName() on the (absent) resourceFile part and throws
-        # a NullPointerException, surfacing as an opaque "Failed to submit batch: 500".
-        # Fail fast with actionable guidance instead of hitting that crash.
-        if not resource_is_local and (local_py_files or local_jars or local_files):
-            offending = [orig for orig, _ in local_py_files + local_jars + local_files]
-            raise ValueError(
-                "Cannot upload local files when --resource is a remote URI "
-                f"({resource}).\n"
-                "Kyuubi only accepts uploaded extra files when the main resource is "
-                "also uploaded; submitting local files without a local resource triggers "
-                "a server-side error (HTTP 500, ContentDisposition.getFileName()).\n"
-                f"Local files that cannot be uploaded here: {', '.join(offending)}\n"
-                "Resolve by either:\n"
-                "  1. Passing a local path for --resource so it is uploaded with the files, or\n"
-                "  2. Staging these files to S3/HDFS and passing them as remote URIs "
-                "(s3a://, hdfs://, ...), which submits the job without any file upload."
-            )
-
+        
         # Build batch request object
         batch_request = {
             "batchType": batch_type,


### PR DESCRIPTION
Revert "Guard against remote resource + local file uploads (Kyuubi NullPointerException)"

This reverts commit 522fb6f38106b5372f37866e5f61f837e03e1d3b.

Kyuubi has been patched to accept multipart submissions that mix a remote main resource with uploaded local files, so the client-side guard is no longer needed. With the server fixed, the guard would incorrectly reject a now-valid combination (remote --resource + local --files/--jars/--pyfiles), so it is removed along with its documentation note.