### PR TITLE
Add --driver-logs to fetch Spark driver (application) logs

### DIFF
--- a/java/src/main/java/com/nx1/kyuubi/KyuubiClient.java
+++ b/java/src/main/java/com/nx1/kyuubi/KyuubiClient.java
@@ -288,6 +288,17 @@ public class KyuubiClient implements Closeable {
         fetchAndStreamLogs(batchId, consumer);
     }
 
+    /**
+     * Stream the Spark <em>driver</em> logs (application output) to the given consumer.
+     *
+     * <p>This reads the {@code driverLog} endpoint, which surfaces the driver's own
+     * output (the application logs), as opposed to {@link #streamLogs} which returns
+     * Kyuubi's submission-side log.
+     */
+    public void streamDriverLogs(String batchId, LogConsumer consumer) throws IOException {
+        fetchAndStreamDriverLogs(batchId, consumer);
+    }
+
     // ── Convenience methods ────────────────────────────────────────────────────
 
     /**
@@ -417,6 +428,51 @@ public class KyuubiClient implements Closeable {
             from += rows.size();
         }
         log.info("Retrieved {} log lines", printed);
+    }
+
+    /** Safety bound for driverLog paging: never stream more than this many lines. */
+    private static final int DRIVER_LOG_MAX_LINES = 1_000_000;
+
+    /**
+     * Page through the driverLog endpoint. Unlike localLog it returns no reliable
+     * {@code total}, so termination relies on three guards: a short/empty page marks
+     * the end; a page identical to the previous one means the server is not honouring
+     * the {@code from} offset (stop rather than loop); and a hard line cap bounds
+     * output in any case.
+     */
+    private void fetchAndStreamDriverLogs(String batchId, LogConsumer consumer) throws IOException {
+        log.info("Retrieving Spark driver logs for batch {}", batchId);
+        int from    = 0;
+        int size    = 1000;
+        int printed = 0;
+        List<String> prevRows = null;
+
+        while (true) {
+            BatchLogResponse logResp = rest.getBatchLogs(batchId, from, size, "driverLog");
+            List<String> rows = logResp.getLogRowSet();
+            if (rows == null || rows.isEmpty()) break;
+
+            // Server ignored 'from' and returned the same page again → no progress.
+            if (rows.equals(prevRows)) {
+                log.warn("Driver log pagination did not advance (server may not support "
+                        + "paging); stopping to avoid a loop");
+                break;
+            }
+            prevRows = rows;
+
+            boolean truncated = false;
+            for (String line : rows) {
+                consumer.accept(line);
+                if (++printed >= DRIVER_LOG_MAX_LINES) { truncated = true; break; }
+            }
+            if (truncated) {
+                log.warn("Driver log output truncated at {} lines", DRIVER_LOG_MAX_LINES);
+                break;
+            }
+            if (rows.size() < size) break;   // short page = last page
+            from += rows.size();
+        }
+        log.info("Retrieved {} driver log lines", printed);
     }
 
     private String formatHistoryUrl(String appId) {

--- a/java/src/main/java/com/nx1/kyuubi/KyuubiRestClient.java
+++ b/java/src/main/java/com/nx1/kyuubi/KyuubiRestClient.java
@@ -145,9 +145,19 @@ class KyuubiRestClient implements Closeable {
      * @param size  max lines to return
      */
     BatchLogResponse getBatchLogs(String batchId, int from, int size) throws IOException {
+        return getBatchLogs(batchId, from, size, "localLog");
+    }
+
+    /**
+     * Retrieve a page of log lines from the given endpoint.
+     *
+     * @param logType {@code "localLog"} (Kyuubi submission log) or
+     *                {@code "driverLog"} (Spark driver / application log)
+     */
+    BatchLogResponse getBatchLogs(String batchId, int from, int size, String logType) throws IOException {
         URI uri;
         try {
-            uri = new URIBuilder(baseUrl + "/api/v1/batches/" + batchId + "/localLog")
+            uri = new URIBuilder(baseUrl + "/api/v1/batches/" + batchId + "/" + logType)
                     .addParameter("from", String.valueOf(from))
                     .addParameter("size", String.valueOf(size))
                     .build();

--- a/python/README.md
+++ b/python/README.md
@@ -180,7 +180,8 @@ In this example:
 | `--files`          | No       | Files to distribute (comma-separated, local or remote) |
 | `--queue`          | No       | YuniKorn queue name                                    |
 | `--history-server` | No       | Spark History Server URL                               |
-| `--show-logs`      | No       | Display logs after completion                          |
+| `--show-logs`      | No       | Display the Kyuubi submission log after completion      |
+| `--driver-logs`    | No       | Display the Spark driver logs (application output) after completion |
 | `--debug`          | No       | Enable debug logging                                   |
 | `--config-file`    | No       | YAML configuration file                                |
 

--- a/python/kyuubi-submit.py
+++ b/python/kyuubi-submit.py
@@ -400,13 +400,18 @@ class KyuubiBatchSubmitter:
             return None
         return response.json()
     
-    def get_batch_logs(self, batch_id, from_index=0, size=1000):
-        """Get batch logs"""
-        url = urljoin(self.server, f"/api/v1/batches/{batch_id}/localLog")
+    def get_batch_logs(self, batch_id, from_index=0, size=1000, log_type='localLog'):
+        """Get batch logs.
+
+        log_type:
+          'localLog'  - Kyuubi's submission-side log (spark-submit console output).
+          'driverLog' - the Spark driver's own log (application output) from the backend.
+        """
+        url = urljoin(self.server, f"/api/v1/batches/{batch_id}/{log_type}")
         params = {"from": from_index, "size": size}
         response = self.session.get(url, params=params)
         if response.status_code != 200:
-            self.logger.warning(f"Error getting logs: {response.status_code}")
+            self.logger.warning(f"Error getting {log_type}: {response.status_code}")
             return None
         return response.json()
     
@@ -435,8 +440,76 @@ class KyuubiBatchSubmitter:
         
         print("="*132 + "\n")
         self.logger.info(f"Retrieved {total_printed} log lines")
-    
-    def monitor_job(self, batch_id, show_logs=True):
+
+    # Safety bound for driverLog paging: cap total lines so a server that does not
+    # honour the 'from' offset can never cause an unbounded loop.
+    DRIVER_LOG_MAX_LINES = 1_000_000
+
+    def print_all_driver_logs(self, batch_id):
+        """Retrieve and print the Spark driver logs (application output).
+
+        Unlike localLog, the driverLog endpoint does not return a reliable 'total',
+        so termination relies on three guards:
+          1. a short/empty page marks the end of the log;
+          2. a page identical to the previous one means the server is not honouring
+             the 'from' offset (no progress) - stop rather than loop forever;
+          3. a hard DRIVER_LOG_MAX_LINES cap bounds output in any case.
+        """
+        self.logger.info("Retrieving Spark driver logs...")
+
+        from_index = 0
+        size = 1000
+        total_printed = 0
+        printed_header = False
+        prev_rows = None
+        truncated = False
+
+        while True:
+            log_data = self.get_batch_logs(batch_id, from_index, size, log_type='driverLog')
+            if not log_data:
+                break
+            log_rows = log_data.get('logRowSet', [])
+            if not log_rows:
+                break
+
+            # Guard 2: server ignored 'from' and returned the same page again.
+            if prev_rows is not None and log_rows == prev_rows:
+                self.logger.warning(
+                    "Driver log pagination did not advance (server may not support "
+                    "paging); stopping to avoid a loop."
+                )
+                break
+            prev_rows = log_rows
+
+            if not printed_header:
+                print("\n" + "="*60 + " DRIVER LOG " + "="*60)
+                printed_header = True
+
+            for row in log_rows:
+                print(row)
+                total_printed += 1
+                if total_printed >= self.DRIVER_LOG_MAX_LINES:
+                    truncated = True
+                    break
+
+            if truncated:
+                break
+            # Guard 1: no dependable 'total'; a short/empty page is the last one.
+            if len(log_rows) < size:
+                break
+            from_index += len(log_rows)
+
+        if printed_header:
+            print("="*132 + "\n")
+            if truncated:
+                self.logger.warning(
+                    f"Driver log output truncated at {self.DRIVER_LOG_MAX_LINES} lines"
+                )
+            self.logger.info(f"Retrieved {total_printed} driver log lines")
+        else:
+            self.logger.info("No driver logs available")
+
+    def monitor_job(self, batch_id, show_logs=True, show_driver_logs=False):
         """Monitor job until completion"""
         self.logger.info(f"Monitoring batch {batch_id}")
         
@@ -490,6 +563,9 @@ class KyuubiBatchSubmitter:
                         else:
                             self.logger.info("Logs available but not displayed (use --show-logs to see them)")
 
+                        if show_driver_logs:
+                            self.print_all_driver_logs(batch_id)
+
                         # Batch FINISHED != Spark success: require an explicit appState
                         # rather than falling back to the batch state.
                         if not app_state:
@@ -510,6 +586,8 @@ class KyuubiBatchSubmitter:
                             self.logger.error(f"Application diagnostics: {app_diagnostic}")
                         if show_logs:
                             self.print_all_logs(batch_id)
+                        if show_driver_logs:
+                            self.print_all_driver_logs(batch_id)
                         return state
                 
             except Exception as e:
@@ -626,7 +704,8 @@ def main():
     parser.add_argument('--pyfiles', help='Comma-separated Python files (local files will be auto-uploaded)')
     parser.add_argument('--jars', help='Comma-separated JAR files (local files will be auto-uploaded)')
     parser.add_argument('--files', help='Comma-separated files to distribute (local files will be auto-uploaded)')
-    parser.add_argument('--show-logs', action='store_true', help='Display job logs after completion')
+    parser.add_argument('--show-logs', action='store_true', help='Display job logs (Kyuubi submission log) after completion')
+    parser.add_argument('--driver-logs', action='store_true', help='Display Spark driver logs (application output) after completion')
     parser.add_argument('--debug', action='store_true', help='Enable debug logging')
     
     args = parser.parse_args()
@@ -694,7 +773,11 @@ def main():
         # Store batch_id globally for signal handler
         _batch_id = batch_id
         
-        final_state = submitter.monitor_job(batch_id, show_logs=config.get('show_logs', False))
+        final_state = submitter.monitor_job(
+            batch_id,
+            show_logs=config.get('show_logs', False),
+            show_driver_logs=config.get('driver_logs', False)
+        )
         
         if final_state in ['FAILED', 'ERROR']:
             logger.error("Job failed!")


### PR DESCRIPTION
Adds driver-log retrieval via the /driverLog endpoint to both the Python CLI (--driver-logs flag) and the Java client (streamDriverLogs). 
Pagination is bounded (short-page, no-progress, and hard line-cap guards) since driverLog returns no reliable total.